### PR TITLE
Locale support

### DIFF
--- a/imdb-index/src/index/mod.rs
+++ b/imdb-index/src/index/mod.rs
@@ -543,6 +543,8 @@ fn create_name_index(
         count += 1;
         title_count += 1;
 
+        let mut titles = vec![title.to_owned()];
+
         twtr.insert(id.as_bytes(), pos.byte())?;
         // Index the primary name.
         wtr.insert(pos.byte(), title)?;
@@ -550,13 +552,15 @@ fn create_name_index(
             // Index the "original" name.
             wtr.insert(pos.byte(), original_title)?;
             count += 1;
+            titles.push(original_title.to_owned());
         }
         // Now index all of the alternate names, if they exist.
         for result in aka_index.find(id.as_bytes())? {
             let akarecord = result?;
-            if title != akarecord.title {
+            if !titles.contains(&&akarecord.title) {
                 wtr.insert(pos.byte(), &akarecord.title)?;
                 count += 1;
+                titles.push(akarecord.title);
             }
         }
     }

--- a/imdb-index/src/index/mod.rs
+++ b/imdb-index/src/index/mod.rs
@@ -59,6 +59,7 @@ pub struct MediaEntity {
     title: Title,
     episode: Option<Episode>,
     rating: Option<Rating>,
+    best_title: String,
 }
 
 impl MediaEntity {
@@ -75,6 +76,11 @@ impl MediaEntity {
     /// Return a reference to the underlying `Rating`, if it exists.
     pub fn rating(&self) -> Option<&Rating> {
         self.rating.as_ref()
+    }
+
+    /// Return a reference to the underlying best title.
+    pub fn best_title(&self) -> &String {
+        &self.best_title
     }
 }
 
@@ -219,10 +225,14 @@ impl Index {
     /// This returns an error if there was a problem reading the underlying
     /// index. If no such title exists for the given ID, then `None` is
     /// returned.
-    pub fn entity(&mut self, id: &str) -> Result<Option<MediaEntity>> {
+    pub fn entity(
+        &mut self,
+        id: &str,
+        regions: &[String],
+    ) -> Result<Option<MediaEntity>> {
         match self.title(id)? {
             None => Ok(None),
-            Some(title) => self.entity_from_title(title).map(Some),
+            Some(title) => self.entity_from_title(title, regions).map(Some),
         }
     }
 
@@ -230,13 +240,18 @@ impl Index {
     ///
     /// This is like the `entity` method, except it takes a `Title` record as
     /// given.
-    pub fn entity_from_title(&mut self, title: Title) -> Result<MediaEntity> {
+    pub fn entity_from_title(
+        &mut self,
+        title: Title,
+        regions: &[String],
+    ) -> Result<MediaEntity> {
         let episode = match title.kind {
             TitleKind::TVEpisode => self.episode(&title.id)?,
             _ => None,
         };
         let rating = self.rating(&title.id)?;
-        Ok(MediaEntity { title, episode, rating })
+        let best_title = self.best_title(&title, regions)?;
+        Ok(MediaEntity { title, episode, rating, best_title })
     }
 
     /// Returns the `Title` record for the given IMDb ID.
@@ -249,6 +264,53 @@ impl Index {
             None => Ok(None),
             Some(offset) => self.read_record(offset),
         }
+    }
+
+    /// Returns the best title for the given `Title` and regions.
+    ///
+    /// The best_title method takes a title and a list of regions.
+    /// If the list is empty, it returns the title as is.
+    /// If not, it searches through the AKA records associated with the title.
+    /// It looks for the AKA record whose region is earliest in the provided list
+    /// and, if there's a tie, prefers the one with the type "imdbDisplay".
+    /// It returns the title of the best AKA record found,
+    /// or the original title if no suitable AKA record is found.
+    pub fn best_title(
+        &mut self,
+        title: &Title,
+        regions: &[String],
+    ) -> Result<String> {
+        // If regions is empty, return the title
+        if regions.is_empty() {
+            return Ok(title.title.clone());
+        }
+
+        // Find the best aka_record
+        let best_aka_record = self
+            .aka_records(&title.id)?
+            .filter_map(Result::ok)
+            .filter(|aka_record| regions.contains(&aka_record.region))
+            .min_by(|a, b| {
+                let a_index =
+                    regions.iter().position(|r| r == &a.region).unwrap();
+                let b_index =
+                    regions.iter().position(|r| r == &b.region).unwrap();
+
+                // If the regions are the same and the first type contains "imdbDisplay"
+                // prefer the first one, otherwise prefer the second one
+                if a_index == b_index {
+                    if a.types.contains("imdbDisplay") {
+                        return std::cmp::Ordering::Less;
+                    }
+                    return std::cmp::Ordering::Greater;
+                }
+
+                a_index.cmp(&b_index)
+            });
+
+        // Return the title of the best aka_record, or the original title if none was found
+        Ok(best_aka_record
+            .map_or_else(|| title.title.clone(), |aka| aka.title.clone()))
     }
 
     /// Returns an iterator over all `AKA` records for the given IMDb ID.

--- a/imdb-index/src/search.rs
+++ b/imdb-index/src/search.rs
@@ -404,6 +404,14 @@ impl Query {
         self
     }
 
+    /// Add a region, if not already present.
+    fn add_region(&mut self, region: &str) {
+        let region = region.to_uppercase();
+        if !self.regions.contains(&region) {
+            self.regions.push(region);
+        }
+    }
+
     /// Add a region, used to define preferable best_title for MediaEntity
     /// from aka titles.
     ///
@@ -413,14 +421,11 @@ impl Query {
     /// Note that it is not possible to remove regions from an existing
     /// query. Instead, build a new query from scratch.
     pub fn region(mut self, region: &str) -> Query {
-        let region = region.to_uppercase();
-        if !self.regions.contains(&region) {
-            self.regions.push(region);
-        }
+        self.add_region(region);
         self
     }
 
-    /// Set the regions, used to define preferable best_title for MediaEntity
+    /// Add the regions, used to define preferable best_title for MediaEntity
     /// from aka titles.
     ///
     /// Multiple regions can be added to query, search result will depends
@@ -429,7 +434,9 @@ impl Query {
     /// Note that it is not possible to remove regions from an existing
     /// query. Instead, build a new query from scratch.
     pub fn regions(mut self, regions: &[String]) -> Query {
-        self.regions = regions.to_vec();
+        for region in regions {
+            self.add_region(region);
+        }
         self
     }
 

--- a/imdb-index/src/search.rs
+++ b/imdb-index/src/search.rs
@@ -96,13 +96,13 @@ impl Searcher {
                 break;
             }
             let (score, title) = r.into_pair();
-            let entity = self.idx.entity_from_title(title)?;
+            let entity = self.idx.entity_from_title(title, &query.regions)?;
             if query.matches(&entity) {
                 results.push(Scored::new(entity).with_score(score));
             }
         }
         if !query.similarity.is_none() {
-            results.rescore(|e| self.similarity(query, &e.title().title));
+            results.rescore(|e| self.similarity(query, &e.best_title()));
         }
         Ok(results)
     }
@@ -128,7 +128,7 @@ impl Searcher {
             let mut results = SearchResults::new();
             for nresult in nresults.into_vec().into_iter().take(query.size) {
                 let (score, (id, _)) = nresult.into_pair();
-                let entity = match self.idx.entity(&id)? {
+                let entity = match self.idx.entity(&id, &query.regions)? {
                     None => continue,
                     Some(entity) => entity,
                 };
@@ -148,7 +148,8 @@ impl Searcher {
             let mut results = SearchResults::new();
             for tresult in tresults.into_vec().into_iter().take(query.size) {
                 let (score, title) = tresult.into_pair();
-                let entity = self.idx.entity_from_title(title)?;
+                let entity =
+                    self.idx.entity_from_title(title, &query.regions)?;
                 results.push(Scored::new(entity).with_score(score));
             }
             Ok(results)
@@ -156,12 +157,13 @@ impl Searcher {
             let mut results = SearchResults::new();
             for result in rdr.deserialize() {
                 let title = result.map_err(Error::csv)?;
-                let entity = self.idx.entity_from_title(title)?;
+                let entity =
+                    self.idx.entity_from_title(title, &query.regions)?;
                 if query.matches(&entity) {
                     results.push(Scored::new(entity));
                 }
             }
-            results.rescore(|e| self.similarity(query, &e.title().title));
+            results.rescore(|e| self.similarity(query, &e.best_title()));
             Ok(results)
         }
     }
@@ -173,7 +175,7 @@ impl Searcher {
     ) -> Result<SearchResults<MediaEntity>> {
         let mut results = SearchResults::new();
         for ep in self.idx.seasons(tvshow_id)? {
-            let entity = match self.idx.entity(&ep.id)? {
+            let entity = match self.idx.entity(&ep.id, &query.regions)? {
                 None => continue,
                 Some(entity) => entity,
             };
@@ -182,7 +184,7 @@ impl Searcher {
             }
         }
         if !query.similarity.is_none() {
-            results.rescore(|e| self.similarity(query, &e.title().title));
+            results.rescore(|e| self.similarity(query, &e.best_title()));
         }
         Ok(results)
     }
@@ -221,6 +223,7 @@ pub struct Query {
     season: Range<u32>,
     episode: Range<u32>,
     tvshow_id: Option<String>,
+    regions: Vec<String>,
 }
 
 impl Default for Query {
@@ -243,6 +246,7 @@ impl Query {
             season: Range::none(),
             episode: Range::none(),
             tvshow_id: None,
+            regions: vec![],
         }
     }
 
@@ -397,6 +401,35 @@ impl Query {
     /// This automatically limits all results to episodes.
     pub fn tvshow_id(mut self, tvshow_id: &str) -> Query {
         self.tvshow_id = Some(tvshow_id.to_string());
+        self
+    }
+
+    /// Add a region, used to define preferable best_title for MediaEntity
+    /// from aka titles.
+    ///
+    /// Multiple regions can be added to query, search result will depends
+    /// on their order.
+    ///
+    /// Note that it is not possible to remove regions from an existing
+    /// query. Instead, build a new query from scratch.
+    pub fn region(mut self, region: &str) -> Query {
+        let region = region.to_uppercase();
+        if !self.regions.contains(&region) {
+            self.regions.push(region);
+        }
+        self
+    }
+
+    /// Set the regions, used to define preferable best_title for MediaEntity
+    /// from aka titles.
+    ///
+    /// Multiple regions can be added to query, search result will depends
+    /// on their order.
+    ///
+    /// Note that it is not possible to remove regions from an existing
+    /// query. Instead, build a new query from scratch.
+    pub fn regions(mut self, regions: &[String]) -> Query {
+        self.regions = regions.to_vec();
         self
     }
 
@@ -601,6 +634,9 @@ impl FromStr for Query {
                     } else {
                         q.name_scorer = Some(val.parse()?);
                     }
+                }
+                "region" => {
+                    q = q.region(val);
                 }
                 unk => return Err(Error::unknown_directive(unk)),
             }
@@ -905,6 +941,13 @@ mod tests {
 
         let q: Query = "{year:-}".parse().unwrap();
         assert_eq!(q, Query::new());
+
+        let q: Query = "{region:us}{region:GB}".parse().unwrap();
+        assert_eq!(q, Query::new().region("US").region("GB"));
+        assert_eq!(
+            q,
+            Query::new().regions(&["US".to_string(), "GB".to_string()])
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ struct Args {
     update_index: bool,
     min_votes: u32,
     rename_action: RenameAction,
+    regions: Vec<String>,
 }
 
 impl Args {
@@ -167,6 +168,12 @@ impl Args {
                 RenameAction::Rename
             }
         };
+        let regions = matches
+            .values_of_lossy("region")
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|s| s.to_uppercase())
+            .collect();
         Ok(Args {
             data_dir: data_dir,
             dest_dir: dest_dir,
@@ -189,6 +196,7 @@ impl Args {
             update_index: matches.is_present("update-index"),
             min_votes: min_votes,
             rename_action: rename_action,
+            regions: regions,
         })
     }
 
@@ -208,11 +216,11 @@ impl Args {
     }
 
     fn download_all(&self) -> anyhow::Result<bool> {
-        download::download_all(&self.data_dir)
+        download::download_all(&self.data_dir, &self.regions)
     }
 
     fn download_all_update(&self) -> anyhow::Result<()> {
-        download::update_all(&self.data_dir)
+        download::update_all(&self.data_dir, &self.regions)
     }
 }
 
@@ -330,6 +338,13 @@ fn app() -> clap::App<'static, 'static> {
              .conflicts_with("symlink")
              .help("Create a hardlink instead of renaming. \
                     This doesn't work when renaming directories."))
+        .arg(Arg::with_name("region")
+             .long("region")
+             .short("r")
+             .multiple(true)
+             .takes_value(true)
+             .help("Region(s) from aka titles to include local titles. \
+                    By default, only the primary title is used."))
 }
 
 /// Collect all file paths from a sequence of OsStrings from the command line.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
 
-use imdb_index::{Index, IndexBuilder, NgramType, Searcher};
+use imdb_index::{Index, IndexBuilder, NgramType, Query, Searcher};
 use lazy_static::lazy_static;
 use tabwriter::TabWriter;
 use walkdir::WalkDir;
@@ -59,7 +59,10 @@ fn try_main() -> anyhow::Result<()> {
     let mut searcher = args.searcher()?;
     let results = match args.query {
         None => None,
-        Some(ref query) => Some(searcher.search(&query.parse()?)?),
+        Some(ref query) => Some(
+            searcher
+                .search(&query.parse::<Query>()?.regions(&args.regions))?,
+        ),
     };
     if args.files.is_empty() {
         let results = match results {
@@ -75,7 +78,8 @@ fn try_main() -> anyhow::Result<()> {
         .good_threshold(0.25)
         .regex_episode(&args.regex_episode)
         .regex_season(&args.regex_season)
-        .regex_year(&args.regex_year);
+        .regex_year(&args.regex_year)
+        .regions(&args.regions);
     if let Some(ref results) = results {
         builder.force(choose(&mut searcher, results.as_slice(), 0.25)?);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,7 +114,7 @@ fn write_tsv_title<W: io::Write>(
         score,
         ent.title().id,
         ent.title().kind,
-        ent.title().title,
+        ent.best_title(),
         ent.title()
             .start_year
             .map(|y| y.to_string())
@@ -145,7 +145,7 @@ fn write_tsv_episode<W: io::Write>(
         score,
         ent.title().id,
         ent.title().kind,
-        ent.title().title,
+        ent.best_title(),
         ent.title()
             .start_year
             .map(|y| y.to_string())


### PR DESCRIPTION
**Motivation**: Support localized title names from AKAs for search and renaming. Resolves ["locale support ? #6 "](https://github.com/BurntSushi/imdb-rename/issues/6) request

**Dataset downloading and indexing**: The `imdb-rename` command-line tool now includes a new argument called “regions.” This argument accepts a set of region abbreviations (such as US, GB, DE), corresponding to the region column in the IMDb “AKA” csv. During dataset download and processing of the aka csv, the AKA index stores only lines that have regions mentioned in the regions list. This can result in more than one line or no lines for a title if there are no entries with the requested regions, in contrast to the previous behavior. When creating the names index, all different variants of titles are indexed alongside primary and original titles from the `title.basic` dataset. This enhancement allows the names index to search by localized title names. If no AKAs are stored for a title, it does not impact the search because primary and original titles from the `title.basics` dataset are still indexed by the names index.

**Backward compatibility**: If no regions are set, downloading and indexing behave as they did before: only the first line for each title is stored in the AKA dataset and indexed by the names index.

**Search and rename**: A new field called `best_title` has been added to the `MediaEntry`. It is used for renaming or representing query results. This field is filled by searching the aka index for the best-matched title name. The `best_title` is chosen from the AKA strings that have a region from the `regions` list. Regions mentioned earlier in the list are given preference. If there are two lines with the same region, the one with the type `imdbDisplay` is preferred. If no localized titles are found, the primary title from `title.basics` is used as the `best_title`.

Additionally, a {region} directive has been added to the `Query`, allowing users to set preferred regions in the query string.

**Backward compatibility**:  If no regions are set, `best_title` will be filled with `title.title` as it was before.